### PR TITLE
Reuse stream of HTTP request instead of create new stream

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -5,6 +5,7 @@ namespace RoyVoetman\FlysystemGitlab;
 use GuzzleHttp\Client as HttpClient;
 use GuzzleHttp\Psr7\Response;
 use InvalidArgumentException;
+use Psr\Http\Message\StreamInterface;
 
 /**
  * Class GitlabAdapter
@@ -79,6 +80,21 @@ class Client
         $response = $this->request('GET', "files/$path");
     
         return $this->responseContents($response);
+    }
+
+    /**
+     * @param $path
+     *
+     * @return resource|null
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     */
+    public function readStream($path)
+    {
+        $path = urlencode($path);
+
+        $response = $this->request('GET', "files/$path");
+
+        return $response->getBody()->detach();
     }
     
     /**

--- a/src/Client.php
+++ b/src/Client.php
@@ -92,7 +92,7 @@ class Client
     {
         $path = urlencode($path);
 
-        $response = $this->request('GET', "files/$path");
+        $response = $this->request('GET', "files/$path/raw");
 
         return $response->getBody()->detach();
     }

--- a/src/GitlabAdapter.php
+++ b/src/GitlabAdapter.php
@@ -147,17 +147,15 @@ class GitlabAdapter implements FilesystemAdapter
      */
     public function readStream(string $path)
     {
-        if (false === ($fp = fopen('php://memory', 'r+'))) {
-            throw UnableToReadFile::fromLocation($path, 'Unable to open memory stream');
+        try {
+            if (null === ($resource = $this->client->readStream($this->prefixer->prefixPath($path)))) {
+                throw UnableToReadFile::fromLocation($path, 'Empty content');
+            }
+
+            return $resource;
+        } catch (Throwable $e) {
+            throw UnableToReadFile::fromLocation($path, $e->getMessage(), $e);
         }
-
-        if (false === fwrite($fp, $this->read($path))) {
-            throw UnableToReadFile::fromLocation($path, 'Unable to write stream');
-        }
-
-        fseek($fp, 0);
-
-        return $fp;
     }
     
     /**

--- a/tests/GitlabAdapterTest.php
+++ b/tests/GitlabAdapterTest.php
@@ -78,7 +78,7 @@ class GitlabAdapterTest extends TestCase
         $stream = $this->gitlabAdapter->readStream('README.md');
 
         $this->assertIsResource($stream);
-        $this->assertEquals(stream_get_contents($stream, null, 0), $this->gitlabAdapter->read('README.md'));
+        $this->assertEquals(stream_get_contents($stream, -1, 0), $this->gitlabAdapter->read('README.md'));
     }
 
     /**


### PR DESCRIPTION
Reuse stream of HTTP request instead of create new stream.

If you can test with your test environment ;).