### PR TITLE
add compatibility with flysystem 3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,10 +20,10 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
-        "guzzlehttp/guzzle": "^6.3",
-        "league/flysystem": "^2.0.0"
+        "guzzlehttp/guzzle": "^7.0",
+        "league/flysystem": "^2.0 || ^3.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.2"

--- a/src/GitlabAdapter.php
+++ b/src/GitlabAdapter.php
@@ -11,6 +11,7 @@ use League\Flysystem\FilesystemAdapter;
 use League\Flysystem\FilesystemException;
 use League\Flysystem\PathPrefixer;
 use League\Flysystem\StorageAttributes;
+use League\Flysystem\UnableToCheckExistence;
 use League\Flysystem\UnableToCheckFileExistence;
 use League\Flysystem\UnableToCopyFile;
 use League\Flysystem\UnableToCreateDirectory;
@@ -377,5 +378,16 @@ class GitlabAdapter implements FilesystemAdapter
     public function setClient(Client $client)
     {
         $this->client = $client;
+    }
+
+    public function directoryExists(string $path): bool
+    {
+        try {
+            $tree = $this->client->tree($this->prefixer->prefixPath($path));
+
+            return (bool)count($tree->current());
+        } catch (Throwable $e) {
+            throw UnableToCheckExistence::forLocation($path, $e);
+        }
     }
 }

--- a/tests/GitlabAdapterTest.php
+++ b/tests/GitlabAdapterTest.php
@@ -454,6 +454,25 @@ class GitlabAdapterTest extends TestCase
 
         $this->gitlabAdapter->setVisibility('README.md', 0777);
     }
+
+    /**
+     * @test
+     */
+    public function it_can_check_directory_if_exists()
+    {
+        $dir = 'test-dir/test-dir2/test-dir3';
+        $this->gitlabAdapter->createDirectory($dir, new Config());
+        $this->assertTrue($this->gitlabAdapter->directoryExists($dir));
+        $this->gitlabAdapter->deleteDirectory($dir);
+    }
+
+    /**
+     * @test
+     */
+    public function it_cannot_check_if_directory_exists()
+    {
+        $this->assertFalse($this->gitlabAdapter->directoryExists('test_non_existent_dir'));
+    }
     
     private function setInvalidToken()
     {


### PR DESCRIPTION
A new version of flysystem was launched and currently is blocking the[ bundle upgrade](https://github.com/1up-lab/OneupFlysystemBundle/issues/258). This should make it compatible with the new interface.