### PR TITLE
feat: drop support for PHP < 8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,3 +49,6 @@ All notable changes to `flysystem-gitlab-storage` will be documented in this fil
 
 ### 2.0.4 - 2020-12-16
 - Savings HTTP exchanges with HEAD request
+
+### 2.xx - 2024-xx-xx
+- Moved minimum PHP version to 8.1

--- a/composer.json
+++ b/composer.json
@@ -20,13 +20,13 @@
         }
     ],
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "guzzlehttp/guzzle": "^7.0",
         "league/flysystem": "^2.0 || ^3.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.2"
+        "phpunit/phpunit": "^10.5.11 || ^11.0.4"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,21 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit backupGlobals="false"
-         backupStaticAttributes="false"
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          bootstrap="vendor/autoload.php"
          colors="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         processIsolation="false"
-         stopOnFailure="false">
-    <testsuites>
-        <testsuite name="Gitlab Test Suite">
-            <directory suffix="Test.php">./tests</directory>
-        </testsuite>
-    </testsuites>
-    <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
-            <directory suffix=".php">./src</directory>
-        </whitelist>
-    </filter>
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+>
+  <testsuites>
+    <testsuite name="Gitlab Test Suite">
+      <directory>./tests</directory>
+    </testsuite>
+  </testsuites>
+
+  <source>
+    <include>
+      <directory>./src</directory>
+    </include>
+  </source>
+
 </phpunit>

--- a/src/GitlabAdapter.php
+++ b/src/GitlabAdapter.php
@@ -34,28 +34,13 @@ class GitlabAdapter implements FilesystemAdapter
 {
     const UPLOADED_FILE_COMMIT_MESSAGE = 'Uploaded file via Gitlab API';
     const DELETED_FILE_COMMIT_MESSAGE = 'Deleted file via Gitlab API';
-    
-    /**
-     * @var \RoyVoetman\FlysystemGitlab\Client
-     */
+
     protected Client $client;
-    
-    /**
-     * @var \League\Flysystem\PathPrefixer
-     */
+
     protected PathPrefixer $prefixer;
-    
-    /**
-     * @var \League\MimeTypeDetection\ExtensionMimeTypeDetector
-     */
+
     protected ExtensionMimeTypeDetector $mimeTypeDetector;
-    
-    /**
-     * GitlabAdapter constructor.
-     *
-     * @param  \RoyVoetman\FlysystemGitlab\Client  $client
-     * @param  string  $prefix
-     */
+
     public function __construct(Client $client, $prefix = '')
     {
         $this->client = $client;
@@ -64,10 +49,7 @@ class GitlabAdapter implements FilesystemAdapter
     }
     
     /**
-     * @param  string  $path
-     *
-     * @throws \League\Flysystem\UnableToCheckFileExistence
-     * @return bool
+     * @inheritdoc
      */
     public function fileExists(string $path): bool
     {
@@ -83,13 +65,9 @@ class GitlabAdapter implements FilesystemAdapter
     
         return true;
     }
-    
+
     /**
-     * @param  string  $path
-     * @param  string  $contents
-     * @param  \League\Flysystem\Config  $config
-     *
-     * @throws \League\Flysystem\UnableToWriteFile
+     * @inheritdoc
      */
     public function write(string $path, string $contents, Config $config): void
     {
@@ -103,13 +81,9 @@ class GitlabAdapter implements FilesystemAdapter
             throw UnableToWriteFile::atLocation($path, $e->getMessage(), $e);
         }
     }
-    
+
     /**
-     * @param  string  $path
-     * @param  resource  $contents
-     * @param  \League\Flysystem\Config  $config
-     *
-     * @throws UnableToWriteFile
+     * @inheritdoc
      */
     public function writeStream(string $path, $contents, Config $config): void
     {
@@ -123,12 +97,9 @@ class GitlabAdapter implements FilesystemAdapter
             throw UnableToWriteFile::atLocation($path, $e->getMessage(), $e);
         }
     }
-    
+
     /**
-     * @param  string  $path
-     *
-     * @throws \League\Flysystem\UnableToReadFile
-     * @return string
+     * @inheritdoc
      */
     public function read(string $path): string
     {
@@ -138,11 +109,9 @@ class GitlabAdapter implements FilesystemAdapter
             throw UnableToReadFile::fromLocation($path, $e->getMessage(), $e);
         }
     }
-    
+
     /**
-     * @param  string  $path
-     *
-     * @throws \League\Flysystem\UnableToReadFile
+     * @inheritdoc
      */
     public function readStream(string $path)
     {
@@ -156,11 +125,9 @@ class GitlabAdapter implements FilesystemAdapter
             throw UnableToReadFile::fromLocation($path, $e->getMessage(), $e);
         }
     }
-    
+
     /**
-     * @param  string  $path
-     *
-     * @throws \League\Flysystem\UnableToDeleteFile
+     * @inheritdoc
      */
     public function delete(string $path): void
     {
@@ -170,11 +137,9 @@ class GitlabAdapter implements FilesystemAdapter
             throw UnableToDeleteFile::atLocation($path, $e->getMessage(), $e);
         }
     }
-    
+
     /**
-     * @param  string  $path
-     *
-     * @throws \League\Flysystem\FilesystemException
+     * @inheritdoc
      */
     public function deleteDirectory(string $path): void
     {
@@ -191,12 +156,9 @@ class GitlabAdapter implements FilesystemAdapter
             }
         }
     }
-    
+
     /**
-     * @param  string  $path
-     * @param  \League\Flysystem\Config  $config
-     *
-     * @throws \League\Flysystem\UnableToCreateDirectory
+     * @inheritdoc
      */
     public function createDirectory(string $path, Config $config): void
     {
@@ -208,10 +170,9 @@ class GitlabAdapter implements FilesystemAdapter
             throw UnableToCreateDirectory::dueToFailure($path, $e);
         }
     }
-    
+
     /**
-     * @param  string  $path
-     * @param  mixed  $visibility
+     * @inheritdoc
      *
      * @throws \League\Flysystem\UnableToSetVisibility
      */
@@ -221,9 +182,8 @@ class GitlabAdapter implements FilesystemAdapter
     }
     
     /**
-     * @param  string  $path
+     * @inheritdoc
      *
-     * @return \League\Flysystem\FileAttributes
      * @throws \League\Flysystem\UnableToSetVisibility
      */
     public function visibility(string $path): FileAttributes
@@ -232,10 +192,9 @@ class GitlabAdapter implements FilesystemAdapter
     }
     
     /**
-     * @param  string  $path
+     * @inheritdoc
      *
      * @throws \League\Flysystem\UnableToRetrieveMetadata
-     * @return \League\Flysystem\FileAttributes
      */
     public function mimeType(string $path): FileAttributes
     {
@@ -249,10 +208,7 @@ class GitlabAdapter implements FilesystemAdapter
     }
     
     /**
-     * @param  string  $path
-     *
-     * @throws \League\Flysystem\UnableToRetrieveMetadata
-     * @return \League\Flysystem\FileAttributes
+     * @inheritdoc
      */
     public function lastModified(string $path): FileAttributes
     {
@@ -270,12 +226,9 @@ class GitlabAdapter implements FilesystemAdapter
             throw UnableToRetrieveMetadata::lastModified($path, $e->getMessage(), $e);
         }
     }
-    
+
     /**
-     * @param  string  $path
-     *
-     * @throws \League\Flysystem\UnableToRetrieveMetadata
-     * @return \League\Flysystem\FileAttributes
+     * @inheritdoc
      */
     public function fileSize(string $path): FileAttributes
     {
@@ -289,11 +242,7 @@ class GitlabAdapter implements FilesystemAdapter
     }
     
     /**
-     * @param string $path
-     * @param bool   $deep
-     *
-     * @throws FilesystemException
-     * @return iterable<StorageAttributes>
+     * @inheritdoc
      */
     public function listContents(string $path, bool $deep): iterable
     {
@@ -319,11 +268,7 @@ class GitlabAdapter implements FilesystemAdapter
     }
     
     /**
-     * @param  string  $source
-     * @param  string  $destination
-     * @param  \League\Flysystem\Config  $config
-     *
-     * @throws \League\Flysystem\UnableToMoveFile
+     * @inheritdoc
      */
     public function move(string $source, string $destination, Config $config): void
     {
@@ -343,11 +288,7 @@ class GitlabAdapter implements FilesystemAdapter
     }
     
     /**
-     * @param  string  $source
-     * @param  string  $destination
-     * @param  \League\Flysystem\Config  $config
-     *
-     * @throws \League\Flysystem\UnableToCopyFile
+     * @inheritdoc
      */
     public function copy(string $source, string $destination, Config $config): void
     {
@@ -363,23 +304,20 @@ class GitlabAdapter implements FilesystemAdapter
             throw UnableToCopyFile::fromLocationTo($source, $destination, $e);
         }
     }
-    
-    /**
-     * @return \RoyVoetman\FlysystemGitlab\Client
-     */
+
     public function getClient(): Client
     {
         return $this->client;
     }
-    
-    /**
-     * @param  \RoyVoetman\FlysystemGitlab\Client  $client
-     */
+
     public function setClient(Client $client)
     {
         $this->client = $client;
     }
 
+    /**
+     * @inheritdoc
+     */
     public function directoryExists(string $path): bool
     {
         try {

--- a/src/UnableToRetrieveFileTree.php
+++ b/src/UnableToRetrieveFileTree.php
@@ -15,7 +15,7 @@ use RuntimeException;
 final class UnableToRetrieveFileTree extends RuntimeException implements FilesystemOperationFailed
 {
     /**
-     * @return string
+     * @see FilesystemOperationFailed::operation()
      */
     public function operation(): string
     {

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -3,18 +3,13 @@
 namespace RoyVoetman\FlysystemGitlab\Tests;
 
 use GuzzleHttp\Exception\ClientException;
+use PHPUnit\Framework\Attributes\Test;
 use RoyVoetman\FlysystemGitlab\Client;
 
 class ClientTest extends TestCase
 {
-    /**
-     * @var \RoyVoetman\FlysystemGitlab\Client
-     */
-    protected $client;
+    protected Client $client;
 
-    /**
-     *
-     */
     public function setUp(): void
     {
         parent::setUp();
@@ -22,17 +17,13 @@ class ClientTest extends TestCase
         $this->client = $this->getClientInstance();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_can_be_instantiated()
     {
         $this->assertInstanceOf(Client::class, $this->getClientInstance());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_can_read_a_file()
     {
         $meta = $this->client->read('README.md');
@@ -42,9 +33,7 @@ class ClientTest extends TestCase
         $this->assertArrayHasKey('lastCommitId', $meta);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_can_read_a_file_raw()
     {
         $content = $this->client->readRaw('README.md');
@@ -52,37 +41,31 @@ class ClientTest extends TestCase
         $this->assertStringStartsWith('# Testing repo for `flysystem-gitlab`', $content);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_can_create_a_file()
     {
         $contents = $this->client->upload('testing.md', '# Testing create', 'Created file');
 
         $this->assertStringStartsWith('# Testing create', $this->client->readRaw('testing.md'));
-        $this->assertTrue($contents === [
+        $this->assertSame($contents, [
                 'file_path' => 'testing.md',
                 'branch'    => $this->client->getBranch()
             ]);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_can_update_a_file()
     {
         $contents = $this->client->upload('testing.md', '# Testing update', 'Updated file', true);
 
         $this->assertStringStartsWith('# Testing update', $this->client->readRaw('testing.md'));
-        $this->assertTrue($contents === [
+        $this->assertSame($contents, [
                 'file_path' => 'testing.md',
                 'branch'    => $this->client->getBranch()
             ]);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_can_delete_a_file()
     {
         $this->client->delete('testing.md', 'Deleted file');
@@ -92,9 +75,7 @@ class ClientTest extends TestCase
         $this->client->read('testing.md');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_can_create_a_file_from_stream()
     {
         $stream = fopen(__DIR__.'/assets/testing.txt', 'r+');
@@ -104,7 +85,7 @@ class ClientTest extends TestCase
         fclose($stream);
 
         $this->assertStringStartsWith('File for testing file streams', $this->client->readRaw('testing.txt'));
-        $this->assertTrue($contents === [
+        $this->assertSame($contents, [
                 'file_path' => 'testing.txt',
                 'branch'    => $this->client->getBranch()
             ]);
@@ -113,9 +94,7 @@ class ClientTest extends TestCase
         $this->client->delete('testing.txt', 'Deleted file');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_can_not_a_create_file_from_stream_without_a_valid_stream()
     {
         $this->expectException(\InvalidArgumentException::class);
@@ -123,16 +102,14 @@ class ClientTest extends TestCase
         $this->client->uploadStream('testing.txt', 'string of data', 'Created file');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_can_retrieve_a_file_tree()
     {
         $contents = $this->client->tree();
     
         $content = $contents->current();
 
-        $this->assertTrue(is_array($content));
+        $this->assertIsArray($content);
         $this->assertArrayHasKey('id', $content[0]);
         $this->assertArrayHasKey('name', $content[0]);
         $this->assertArrayHasKey('type', $content[0]);
@@ -140,28 +117,24 @@ class ClientTest extends TestCase
         $this->assertArrayHasKey('mode', $content[0]);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_can_retrieve_a_file_tree_recursive()
     {
         $contents = $this->client->tree('/', true);
     
         $content = $contents->current();
 
-        $this->assertTrue(is_array($content));
+        $this->assertIsArray($content);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_can_retrieve_a_file_tree_of_a_subdirectory()
     {
         $contents = $this->client->tree('recursive', true);
     
         $content = $contents->current();
 
-        $this->assertTrue(is_array($content));
+        $this->assertIsArray($content);
         $this->assertArrayHasKey('id', $content[0]);
         $this->assertArrayHasKey('name', $content[0]);
         $this->assertArrayHasKey('type', $content[0]);
@@ -169,33 +142,27 @@ class ClientTest extends TestCase
         $this->assertArrayHasKey('mode', $content[0]);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_can_change_the_branch()
     {
         $this->client->setBranch('dev');
 
-        $this->assertEquals($this->client->getBranch(), 'dev');
+        $this->assertEquals('dev', $this->client->getBranch());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_can_change_the_project_id()
     {
         $this->client->setProjectId('12345678');
 
-        $this->assertEquals($this->client->getProjectId(), '12345678');
+        $this->assertEquals('12345678', $this->client->getProjectId());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_can_change_the_personal_access_token()
     {
         $this->client->setPersonalAccessToken('12345678');
 
-        $this->assertEquals($this->client->getPersonalAccessToken(), '12345678');
+        $this->assertEquals('12345678', $this->client->getPersonalAccessToken());
     }
 }

--- a/tests/GitlabAdapterTest.php
+++ b/tests/GitlabAdapterTest.php
@@ -13,45 +13,34 @@ use League\Flysystem\UnableToMoveFile;
 use League\Flysystem\UnableToReadFile;
 use League\Flysystem\UnableToSetVisibility;
 use League\Flysystem\UnableToWriteFile;
+use PHPUnit\Framework\Attributes\Test;
 use RoyVoetman\FlysystemGitlab\Client;
 use RoyVoetman\FlysystemGitlab\GitlabAdapter;
 
 class GitlabAdapterTest extends TestCase
 {
-    /**
-     * @var \RoyVoetman\FlysystemGitlab\GitlabAdapter
-     */
     protected GitlabAdapter $gitlabAdapter;
-    
-    /**
-     *
-     */
+
     public function setUp(): void
     {
         parent::setUp();
         
         $this->gitlabAdapter = $this->getAdapterInstance();
     }
-    
-    /**
-     * @test
-     */
+
+    #[Test]
     public function it_can_be_instantiated()
     {
         $this->assertInstanceOf(GitlabAdapter::class, $this->getAdapterInstance());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_can_retrieve_client_instance()
     {
         $this->assertInstanceOf(Client::class, $this->gitlabAdapter->getClient());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_can_set_client_instance()
     {
         $this->setInvalidProjectId();
@@ -60,9 +49,7 @@ class GitlabAdapterTest extends TestCase
             ->getProjectId(), '123');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_can_read_a_file()
     {
         $response = $this->gitlabAdapter->read('README.md');
@@ -70,9 +57,7 @@ class GitlabAdapterTest extends TestCase
         $this->assertStringStartsWith('# Testing repo for `flysystem-gitlab`', $response);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_can_read_a_file_into_a_stream()
     {
         $stream = $this->gitlabAdapter->readStream('README.md');
@@ -81,9 +66,7 @@ class GitlabAdapterTest extends TestCase
         $this->assertEquals(stream_get_contents($stream, -1, 0), $this->gitlabAdapter->read('README.md'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_throws_when_read_failed()
     {
         $this->setInvalidProjectId();
@@ -93,9 +76,7 @@ class GitlabAdapterTest extends TestCase
         $this->gitlabAdapter->read('README.md');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_can_determine_if_a_project_has_a_file()
     {
         $this->assertTrue($this->gitlabAdapter->fileExists('/README.md'));
@@ -103,9 +84,7 @@ class GitlabAdapterTest extends TestCase
         $this->assertFalse($this->gitlabAdapter->fileExists('/I_DONT_EXIST.md'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_throws_when_file_existence_failed()
     {
         $this->setInvalidToken();
@@ -115,9 +94,7 @@ class GitlabAdapterTest extends TestCase
         $this->gitlabAdapter->fileExists('/README.md');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_can_delete_a_file()
     {
         $this->gitlabAdapter->write('testing.md', '# Testing create', new Config());
@@ -129,9 +106,7 @@ class GitlabAdapterTest extends TestCase
         $this->assertFalse($this->gitlabAdapter->fileExists('/testing.md'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_returns_false_when_delete_failed()
     {
         $this->setInvalidProjectId();
@@ -141,35 +116,29 @@ class GitlabAdapterTest extends TestCase
         $this->gitlabAdapter->delete('testing_renamed.md');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_can_write_a_new_file()
     {
         $this->gitlabAdapter->write('testing.md', '# Testing create', new Config());
 
         $this->assertTrue($this->gitlabAdapter->fileExists('testing.md'));
-        $this->assertEquals($this->gitlabAdapter->read('testing.md'), '# Testing create');
+        $this->assertEquals('# Testing create', $this->gitlabAdapter->read('testing.md'));
 
         $this->gitlabAdapter->delete('testing.md');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_automatically_creates_missing_directories()
     {
         $this->gitlabAdapter->write('/folder/missing/testing.md', '# Testing create folders', new Config());
 
         $this->assertTrue($this->gitlabAdapter->fileExists('/folder/missing/testing.md'));
-        $this->assertEquals($this->gitlabAdapter->read('/folder/missing/testing.md'), '# Testing create folders');
+        $this->assertEquals('# Testing create folders', $this->gitlabAdapter->read('/folder/missing/testing.md'));
 
         $this->gitlabAdapter->delete('/folder/missing/testing.md');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_throws_when_write_failed()
     {
         $this->setInvalidProjectId();
@@ -179,9 +148,7 @@ class GitlabAdapterTest extends TestCase
         $this->gitlabAdapter->write('testing.md', '# Testing create', new Config());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_can_write_a_file_stream()
     {
         $stream = fopen(__DIR__.'/assets/testing.txt', 'r+');
@@ -189,14 +156,12 @@ class GitlabAdapterTest extends TestCase
         fclose($stream);
 
         $this->assertTrue($this->gitlabAdapter->fileExists('testing.txt'));
-        $this->assertEquals($this->gitlabAdapter->read('testing.txt'), 'File for testing file streams');
+        $this->assertEquals('File for testing file streams', $this->gitlabAdapter->read('testing.txt'));
 
         $this->gitlabAdapter->delete('testing.txt');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_throws_when_writing_file_stream_failed()
     {
         $this->setInvalidProjectId();
@@ -208,9 +173,7 @@ class GitlabAdapterTest extends TestCase
         fclose($stream);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_can_override_a_file()
     {
         $this->gitlabAdapter->write('testing.md', '# Testing create', new Config());
@@ -221,10 +184,7 @@ class GitlabAdapterTest extends TestCase
         $this->gitlabAdapter->delete('testing.md');
     }
 
-
-    /**
-     * @test
-     */
+    #[Test]
     public function it_can_override_with_a_file_stream()
     {
         $stream = fopen(__DIR__.'/assets/testing.txt', 'r+');
@@ -236,14 +196,12 @@ class GitlabAdapterTest extends TestCase
         fclose($stream);
 
         $this->assertTrue($this->gitlabAdapter->fileExists('testing.txt'));
-        $this->assertEquals($this->gitlabAdapter->read('testing.txt'), 'File for testing file streams!');
+        $this->assertEquals('File for testing file streams!', $this->gitlabAdapter->read('testing.txt'));
 
         $this->gitlabAdapter->delete('testing.txt');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_can_move_a_file()
     {
         $this->gitlabAdapter->write('testing.md', '# Testing move', new Config());
@@ -253,14 +211,12 @@ class GitlabAdapterTest extends TestCase
         $this->assertFalse($this->gitlabAdapter->fileExists('testing.md'));
         $this->assertTrue($this->gitlabAdapter->fileExists('testing_move.md'));
 
-        $this->assertEquals($this->gitlabAdapter->read('testing_move.md'), '# Testing move');
+        $this->assertEquals('# Testing move', $this->gitlabAdapter->read('testing_move.md'));
 
         $this->gitlabAdapter->delete('testing_move.md');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_throws_when_move_failed()
     {
         $this->setInvalidProjectId();
@@ -270,9 +226,7 @@ class GitlabAdapterTest extends TestCase
         $this->gitlabAdapter->move('testing_move.md', 'testing.md', new Config());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_can_copy_a_file()
     {
         $this->gitlabAdapter->write('testing.md', '# Testing copy', new Config());
@@ -289,9 +243,7 @@ class GitlabAdapterTest extends TestCase
         $this->gitlabAdapter->delete('testing_copy.md');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_throws_when_copy_failed()
     {
         $this->setInvalidProjectId();
@@ -301,9 +253,7 @@ class GitlabAdapterTest extends TestCase
         $this->gitlabAdapter->copy('testing_copy.md', 'testing.md', new Config());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_can_create_a_directory()
     {
         $this->gitlabAdapter->createDirectory('/testing', new Config());
@@ -313,9 +263,7 @@ class GitlabAdapterTest extends TestCase
         $this->gitlabAdapter->delete('/testing/.gitkeep');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_can_retrieve_a_list_of_contents_of_root()
     {
         $list = $this->gitlabAdapter->listContents('/', false);
@@ -329,15 +277,13 @@ class GitlabAdapterTest extends TestCase
 
         foreach ($list as $item) {
             $this->assertInstanceOf(StorageAttributes::class, $item);
-            $this->assertTrue(
-                in_array(['type' => $item['type'], 'path' => $item['path']], $expectedPaths)
+            $this->assertContains(
+                ['type' => $item['type'], 'path' => $item['path']], $expectedPaths
             );
         }
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_can_retrieve_a_list_of_contents_of_root_recursive()
     {
         $list = $this->gitlabAdapter->listContents('/', true);
@@ -352,15 +298,13 @@ class GitlabAdapterTest extends TestCase
 
         foreach ($list as $item) {
             $this->assertInstanceOf(StorageAttributes::class, $item);
-            $this->assertTrue(
-                in_array(['type' => $item['type'], 'path' => $item['path']], $expectedPaths)
+            $this->assertContains(
+                ['type' => $item['type'], 'path' => $item['path']], $expectedPaths
             );
         }
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_can_retrieve_a_list_of_contents_of_sub_folder()
     {
         $list = $this->gitlabAdapter->listContents('/recursive', false);
@@ -370,15 +314,13 @@ class GitlabAdapterTest extends TestCase
 
         foreach ($list as $item) {
             $this->assertInstanceOf(StorageAttributes::class, $item);
-            $this->assertTrue(
-                in_array(['type' => $item['type'], 'path' => $item['path']], $expectedPaths)
+            $this->assertContains(
+                ['type' => $item['type'], 'path' => $item['path']], $expectedPaths
             );
         }
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_can_delete_a_directory()
     {
         $this->gitlabAdapter->createDirectory('/testing', new Config());
@@ -389,10 +331,8 @@ class GitlabAdapterTest extends TestCase
         $this->assertFalse($this->gitlabAdapter->fileExists('/testing/.gitkeep'));
         $this->assertFalse($this->gitlabAdapter->fileExists('/testing/testing.md'));
     }
-    
-    /**
-     * @test
-     */
+
+    #[Test]
     public function it_throws_when_delete_directory_failed()
     {
         $this->setInvalidProjectId();
@@ -401,43 +341,35 @@ class GitlabAdapterTest extends TestCase
         
         $this->gitlabAdapter->deleteDirectory('/testing');
     }
-    
-    /**
-     * @test
-     */
+
+    #[Test]
     public function it_can_retrieve_size()
     {
         $size = $this->gitlabAdapter->fileSize('README.md');
 
         $this->assertInstanceOf(FileAttributes::class, $size);
-        $this->assertEquals($size->fileSize(), 37);
+        $this->assertEquals(37, $size->fileSize());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_can_retrieve_mimetype()
     {
         $metadata = $this->gitlabAdapter->mimeType('README.md');
 
         $this->assertInstanceOf(FileAttributes::class, $metadata);
-        $this->assertEquals($metadata->mimeType(), 'text/markdown');
+        $this->assertEquals('text/markdown', $metadata->mimeType());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_can_not_retrieve_lastModified()
     {
         $lastModified = $this->gitlabAdapter->lastModified('README.md');
 
         $this->assertInstanceOf(FileAttributes::class, $lastModified);
-        $this->assertEquals($lastModified->lastModified(), 1606750652);
+        $this->assertEquals(1606750652, $lastModified->lastModified());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_throws_when_getting_visibility()
     {
         $this->expectException(UnableToSetVisibility::class);
@@ -445,9 +377,7 @@ class GitlabAdapterTest extends TestCase
         $this->gitlabAdapter->visibility('README.md');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_throws_when_setting_visibility()
     {
         $this->expectException(UnableToSetVisibility::class);
@@ -455,9 +385,7 @@ class GitlabAdapterTest extends TestCase
         $this->gitlabAdapter->setVisibility('README.md', 0777);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_can_check_directory_if_exists()
     {
         $dir = 'test-dir/test-dir2/test-dir3';
@@ -466,9 +394,7 @@ class GitlabAdapterTest extends TestCase
         $this->gitlabAdapter->deleteDirectory($dir);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_cannot_check_if_directory_exists()
     {
         $this->assertFalse($this->gitlabAdapter->directoryExists('test_non_existent_dir'));

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -8,31 +8,19 @@ use RoyVoetman\FlysystemGitlab\GitlabAdapter;
 
 abstract class TestCase extends BaseTestCase
 {
-    /**
-     * @var array
-     */
-    protected $config;
-    
-    /**
-     *
-     */
+    protected array $config;
+
     public function setUp(): void
     {
         $this->config = require(__DIR__.'/config/config.testing.php');
     }
-    
-    /**
-     * @return \RoyVoetman\FlysystemGitlab\Client
-     */
+
     protected function getClientInstance(): Client
     {
         return new Client($this->config[ 'project-id' ], $this->config[ 'branch' ], $this->config[ 'base-url' ],
             $this->config[ 'personal-access-token' ]);
     }
-    
-    /**
-     * @return \RoyVoetman\FlysystemGitlab\GitlabAdapter
-     */
+
     protected function getAdapterInstance(): GitlabAdapter
     {
         return new GitlabAdapter($this->getClientInstance());

--- a/tests/config/config.testing.example.php
+++ b/tests/config/config.testing.example.php
@@ -7,7 +7,7 @@ return [
     | Flysystem Adapter for Gitlab configurations
     |--------------------------------------------------------------------------
     |
-    | These configurations will be used in all the the tests to bootstrap
+    | These configurations will be used in all the tests to bootstrap
     | a Client object.
     |
     */


### PR DESCRIPTION
migrate PHPUnit 9 => 11
improve PHPDocs
Flip arguments for test-asserts.
Use recommended tests functions.

I can not run tests, because of missing GitLab instance to test against.